### PR TITLE
Ajout d'un cas de test sur pricer.md

### DIFF
--- a/pricer.md
+++ b/pricer.md
@@ -22,6 +22,7 @@ Puis on ajoute des réductions si le prix total HT dépasse un seuil :
     - Ex : 5 x 345,00 € + taxe 10% → “1840.58 €”
 - 5000 € → Remise 5% :
     - Ex : 5 x 1299,00 € + taxe 10% → “6787.28 €”
+    - Ex : 5 x 999,00 € + taxe 10% → “5332.33 €”
 
 ⚠️ Pour les remises, il n'y a pas besoin d'ajouter de paramètres d'entrée puisque c'est basé sur le prix total HT !
 


### PR DESCRIPTION
Sur le premier cas (nombre d'articles, prix unitaire, taxe), tu as ajouté un cas de test, à fonctionnalité équivalente, pour vérifier l'arrondi au centime supérieur.

En revanche, pour les remises, aucun test ne valide que le calcul de la remise s'effectue bien sur le prix hors taxe. Selon les choix réalisés pour l'implémentation, on peut se tromper et calculer la remise à partir du prix TTC : les 2 tests actuels passent quand même. On peut alors se dire "bon bah j'ai fini !" alors qu'en réalité, le calcul est erroné.

Je t'ai donc proposé un cas de test supplémentaire où le prix HT est inférieur à 5000€ mais où le prix TTC est supérieur à 5000€. C'est donc la remise de 3% qui doit être appliquée, pas celle de 5%. Quelqu'un qui aurait commis l'erreur s'en rendrait alors compte et pourrait corriger son implémentation.